### PR TITLE
Made the theme compatible with Hugo 0.18.

### DIFF
--- a/layouts/partials/custom_image_handler.html
+++ b/layouts/partials/custom_image_handler.html
@@ -3,7 +3,7 @@
   // @summary: jquery implementation
   $(function() {
     // @summary: Use the author's flickr ID to load images from the public flickr feed
-    $.getJSON("http://api.flickr.com/services/feeds/photos_public.gne?id={{ .Site.Author.FlickrID }}&format=json&jsoncallback=?", function(data) {
+    $.getJSON("http://api.flickr.com/services/feeds/photos_public.gne?id={{ .Site.Author.flickrid }}&format=json&jsoncallback=?", function(data) {
       iweblog.application.displayImages(data, 8);
     });
   });

--- a/layouts/partials/custom_image_handler.html
+++ b/layouts/partials/custom_image_handler.html
@@ -3,7 +3,7 @@
   // @summary: jquery implementation
   $(function() {
     // @summary: Use the author's flickr ID to load images from the public flickr feed
-    $.getJSON("http://api.flickr.com/services/feeds/photos_public.gne?id={{ .Site.Author.flickrid }}&format=json&jsoncallback=?", function(data) {
+    $.getJSON("https://api.flickr.com/services/feeds/photos_public.gne?id={{ .Site.Author.flickrid }}&format=json&jsoncallback=?", function(data) {
       iweblog.application.displayImages(data, 8);
     });
   });

--- a/layouts/partials/page_footer.html
+++ b/layouts/partials/page_footer.html
@@ -1,22 +1,22 @@
 <footer>
   <div class="footer_text">
       <div>
-        <h3>Hi, <a href="{{ .Site.Author.AboutPage }}">I'm {{ .Site.Author.FirstName }}</a></h3>
+        <h3>Hi, <a href="{{ .Site.Author.aboutpage }}">I'm {{ .Site.Author.firstname }}</a></h3>
         <p>
           {{ partial "bio.html" . }}
         </p>
       </div>
       <div>
-          <h3><a href="https://www.flickr.com/photos/{{ .Site.Author.FlickrID }}/">Photo Stream</a></h3>
+          <h3><a href="https://www.flickr.com/photos/{{ .Site.Author.flickrid }}/">Photo Stream</a></h3>
           <div id="photos"></div>
         </div>
       </div>
   </div>
 
-  {{ if .Site.Params.ShowCopyright }}
+  {{ if .Site.Params.showcopyright }}
     <div class="footer_copyright">
-      &copy; {{ .Now.Format "2006" }} <a href="{{ .Site.Author.AboutPage }}">{{ .Site.Author.FirstName }} {{ .Site.Author.LastName }}</a>
-      {{ with .Site.Author.Location }} - Made in {{ . }}{{ end }}
+      &copy; {{ .Now.Format "2006" }} <a href="{{ .Site.Author.aboutpage }}">{{ .Site.Author.firstname }} {{ .Site.Author.lastname }}</a>
+      {{ with .Site.Author.location }} - Made in {{ . }}{{ end }}
     </div>
   {{ end }}
 </footer>

--- a/layouts/partials/page_footer.html
+++ b/layouts/partials/page_footer.html
@@ -6,11 +6,13 @@
           {{ partial "bio.html" . }}
         </p>
       </div>
+      {{ if isset .Site.Author "flickrid" | and ( not ( eq .Site.Author.flickrid "" ) ) }}
       <div>
           <h3><a href="https://www.flickr.com/photos/{{ .Site.Author.flickrid }}/">Photo Stream</a></h3>
           <div id="photos"></div>
         </div>
       </div>
+      {{ end }}
   </div>
 
   {{ if .Site.Params.showcopyright }}

--- a/layouts/partials/page_header.html
+++ b/layouts/partials/page_header.html
@@ -1,8 +1,8 @@
 <header>
   <nav>
-    <h1><a href="/">@{{ .Site.Author.Handle }}</a>’s {{ .Site.Title }}.</h1>
+    <h1><a href="/">@{{ .Site.Author.handle }}</a>’s {{ .Site.Title }}.</h1>
     <div class="menu">
-      {{ $.Scratch.Add "sections" .Site.Params.RSSSections }}
+      {{ $.Scratch.Add "sections" .Site.Params.rsssections }}
       <ul>
         {{ range .Site.Menus.main }}
             <li>
@@ -12,7 +12,7 @@
               {{ end }}
             </li>
         {{ end }}
-        {{ with .Site.Author.AboutPage }}<li><a href="{{ . }}">About</a></li>{{ end }}
+        {{ with .Site.Author.aboutpage }}<li><a href="{{ . }}">About</a></li>{{ end }}
       </ul>
     </div>
   </nav>

--- a/layouts/partials/site_header.html
+++ b/layouts/partials/site_header.html
@@ -4,19 +4,19 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="author" content="{{ with .Site.Author.FirstName }}{{ . }}{{ end }}">
-    <meta name="description" content="{{ with .Site.Params.Description }}{{ . }}{{ end }}">
+    <meta name="author" content="{{ with .Site.Author.firstname }}{{ . }}{{ end }}">
+    <meta name="description" content="{{ with .Site.Params.description }}{{ . }}{{ end }}">
     {{ .Hugo.Generator }}
 
     {{ $.Scratch.Add "title" .Site.Title }}
-    <title>{{ with .Title }}{{ if ne . ($.Scratch.Get "title") }}{{ . }} &middot; {{ end }}{{ end }}@{{ .Site.Author.Handle }}’s {{ .Site.Title }}</title>
+    <title>{{ with .Title }}{{ if ne . ($.Scratch.Get "title") }}{{ . }} &middot; {{ end }}{{ end }}@{{ .Site.Author.handle }}’s {{ .Site.Title }}</title>
 
     <link rel="stylesheet" href="{{ .Site.BaseURL }}css/weblog.css" media="screen" charset="utf-8" />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/lightgallery/1.2.14/css/lightgallery.min.css" type="text/css" />
     {{ partial "custom_stylesheets.html" . }}
 
-    {{ if .Site.Params.RSSEnabled }}
-		<link href="{{ .Site.RSSLink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
-		{{ end }}
+    {{ if .Site.Params.rssenabled }}
+	<link href="{{ .Site.RSSLink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
+	{{ end }}
   </head>
   <body class="site">

--- a/layouts/partials/site_header.html
+++ b/layouts/partials/site_header.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="author" content="{{ with .Site.Author.firstname }}{{ . }}{{ end }}">
+    <meta name="author" content="{{ with .Site.Author.firstname }}{{ . }}{{ end }} {{ with .Site.Author.lastname }}{{ . }}{{ end }}">
     <meta name="description" content="{{ with .Site.Params.description }}{{ . }}{{ end }}">
     {{ .Hugo.Generator }}
 

--- a/layouts/rss.xml
+++ b/layouts/rss.xml
@@ -15,7 +15,7 @@
         <title>{{ .Title }}</title>
         <link>{{ .Permalink }}</link>
         <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
-        {{ with .Site.Author.email }}<author>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</author>{{end}}
+        {{ with .Site.Author.email }}<author>{{.}}{{end}} ({{ with .Site.Author.firstname }}{{.}}{{ end }} {{ with .Site.Author.lastname }}{{.}}{{end}})</author>
         <guid>{{ .Permalink }}</guid>
         <description>{{ .Content | html }}</description>
       </item>

--- a/layouts/rss.xml
+++ b/layouts/rss.xml
@@ -1,7 +1,7 @@
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
 
-    <title>@{{ .Site.Author.Handle }}’s {{ .Site.Title }}{{ with .Title }} - {{ . }}{{ end }}</title>
+    <title>@{{ .Site.Author.handle }}’s {{ .Site.Title }}{{ with .Title }} - {{ . }}{{ end }}</title>
     <link>{{ .Permalink }}</link>
     <description>All entries {{ with .Title }}in {{.}} {{ end }}on {{ .Site.Title }}</description>
     <generator>Hugo -- gohugo.io</generator>


### PR DESCRIPTION
At least in Hugo 0.18 (I don't know for prior versions), the variables in the
templates are all set to lowercase even if they are not lowercase in the
config file.

For instance, for a configuration as follows:
[Author]
   Handle = "bla"
the variable must be used as .Site.Author.handle and not .Site.Author.Handle.