### PR TITLE
let have list items the same text size and text color as regular text

### DIFF
--- a/static/css/weblog.css
+++ b/static/css/weblog.css
@@ -68,6 +68,12 @@ header h1 {
   color: #5B636E;
 }
 
+ul > li {
+  font-size: 18px;
+  line-height: 28px;
+  color: #5B636E;
+}
+
 /* Navigation */
 
 nav {


### PR DESCRIPTION
Hi,

Thank you for this nice theme.
List items currently appear smaller and with black text color.
I added a few lines of css to get them in the same size and color as the main text.

Best,
Felix