### PR TITLE
Using the new now function instead of Now on Page object.

### DIFF
--- a/layouts/partials/page_footer.html
+++ b/layouts/partials/page_footer.html
@@ -17,7 +17,7 @@
 
   {{ if .Site.Params.showcopyright }}
     <div class="footer_copyright">
-      &copy; {{ .Now.Format "2006" }} <a href="{{ .Site.Author.aboutpage }}">{{ .Site.Author.firstname }} {{ .Site.Author.lastname }}</a>
+      &copy; {{ now.Format "2006" }} <a href="{{ .Site.Author.aboutpage }}">{{ .Site.Author.firstname }} {{ .Site.Author.lastname }}</a>
       {{ with .Site.Author.location }} - Made in {{ . }}{{ end }}
     </div>
   {{ end }}


### PR DESCRIPTION
The Page object will be deprecated in the next Hugo version (version 0.30), so
this silences a warning which will become an error in the next version.