### PR TITLE
Add capacity to get yearly grouping for microposts.

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,9 +88,9 @@ You can then control the name and weight of these menus in your `config.toml` by
 
 If you aren't sure of how this should look, see how [jnjosh.com uses this in it's config.toml](https://github.com/jnjosh/jnjosh.com/blob/master/config.toml).
 
-**Recommendation:** Add `SectionPagesMenu` to your `config.toml` file.  
-**Recommendation:** Don't set a `menu` in your post's Front Matter unless you want it to display on the navigation.  
-**Recommendation:** Customize the menus that get an RSS icon by adding the `RSSSections` parameter to your `config.toml` file.  
+**Recommendation:** Add `SectionPagesMenu` to your `config.toml` file.
+**Recommendation:** Don't set a `menu` in your post's Front Matter unless you want it to display on the navigation.
+**Recommendation:** Customize the menus that get an RSS icon by adding the `RSSSections` parameter to your `config.toml` file.
 **Recommendation:** Configure the menu items by adding `menu.main` sections to your `config.toml` file.
 
 #### Defining yourself as the Author
@@ -141,11 +141,12 @@ These posts are rendered slightly different with an → to signify that it is re
 | `[author]` - `LastName` | Your last name | Not really. It is used in some places to identify you as the author. |
 | `[author]` - `AboutPage` | `/about` or `http://about.othersite.com` | Only if you want an about page. This is exposed to allow you to link to an external about page as well. If you have a local page it can just be something relative. |
 | `[author]` - `Location` | `Your City` | No. If set, this is added to the Copyright in the footer so you can give some love to your hometown. |
-| `[author]` - `FlickrID` | `Your Flickr ID` | Kind of. The footer shows your photo stream from flickr. If you don't set it you'll see random photos that Flickr serves you. |
-| `[params]` - `Description` | `Describe your site` | No. If set this is added to your pages metadata. |
+| `[author]` - `FlickrID` | `Your Flickr ID` | No. The footer shows your photo stream from flickr. If you don't set it, nothing will be displayed. |
+| `[params]` - `Description` | `Describe your site` | No. If set, this is added to your pages metadata. |
 | `[params]` - `ShowCopyright` | `true` or `false` | No. If true, Copyright text will be added to the footer. |
 | `[params]` - `RSSEnabled` | `true` or `false` | No. If true, RSS pages will be generated. |
-| `[params]` - `RSSSections` | `[ "Posts", "Microposts", "Photos" ]` | If you want RSS links in the menu, Yes. These strings need to be the display name of the section where you want to have an RSS icon displayed. ![rss](https://github.com/jnjosh/internet-weblog/blob/master/images/rss.png) |
+| `[params]` - `RSSSections` | `[ "Posts", "Microposts", "Photos" ]` | If you want RSS links in the menu, yes. These strings need to be the display name of the section where you want to have an RSS icon displayed. ![rss](https://github.com/jnjosh/internet-weblog/blob/master/images/rss.png) |
+| `[params]` - `YearlyMicroposts` | `true` or `false` | No. If true, Microposts will have a page with a yearly grouping just like the posts.  If not present or false, nothing happens. |
 
 Here is an example `config.toml`:
 

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,9 +1,7 @@
 {{ partial "site_header.html" . }}
 {{ partial "page_header.html" . }}
 
-  <main class="content">
-    {{ partial "preview_list.html" . }}
-  </main>
+{{ partial "default_list.html" . }}
 
 {{ partial "page_footer.html" . }}
 {{ partial "site_footer.html" . }}

--- a/layouts/partials/default_list.html
+++ b/layouts/partials/default_list.html
@@ -1,0 +1,3 @@
+<main class="content">
+   {{ partial "preview_list.html" . }}
+</main>

--- a/layouts/partials/yearly_grouping.html
+++ b/layouts/partials/yearly_grouping.html
@@ -1,0 +1,25 @@
+<main class="content">
+  <article class="post-groups">
+    <div class="post-group">
+    {{ range .Data.Pages.GroupByDate "2006" }}
+      <div class="post-group-item">
+        <h3>{{ .Key }}</h3>
+        <ul>
+          {{ range .Pages }}
+            <li>
+              {{ if (not (isset .Params "externalurl")) }}
+                <a rel="full-article" href="{{ .Permalink }}">{{ .Title }}</a>
+                on <time datetime="{{ .Date }}" pubdate="">{{ .Date.Format "January 2" }}</time>
+              {{ else }}
+                <a rel="remote-article" href="{{ .Params.externalurl }}">{{ .Title }} →</a>
+                on
+                <a href="{{ .Permalink }}"> <time datetime="{{ .Date }}" pubdate="">{{ .Date.Format "January 2" }}</time> </a>
+              {{ end }}
+            </li>
+          {{ end }}
+        </ul>
+      </div>
+    {{ end }}
+    </div>
+  </article>
+</main>

--- a/layouts/section/microposts.html
+++ b/layouts/section/microposts.html
@@ -1,0 +1,15 @@
+{{ partial "site_header.html" . }}
+{{ partial "page_header.html" . }}
+
+{{ if isset .Site.Params "yearlymicroposts" | and ( .Site.Params.yearlymicroposts ) }}
+
+{{ partial "yearly_grouping.html" . }}
+
+{{ else }}
+
+{{ partial "default_list.html" . }}
+
+{{ end }}
+
+{{ partial "page_footer.html" . }}
+{{ partial "site_footer.html" . }}

--- a/layouts/section/posts.html
+++ b/layouts/section/posts.html
@@ -1,31 +1,7 @@
 {{ partial "site_header.html" . }}
 {{ partial "page_header.html" . }}
 
-  <main class="content">
-    <article class="post-groups">
-      <div class="post-group">
-      {{ range .Data.Pages.GroupByDate "2006" }}
-        <div class="post-group-item">
-          <h3>{{ .Key }}</h3>
-          <ul>
-            {{ range .Pages }}
-              <li>
-                {{ if (not (isset .Params "externalurl")) }}
-                  <a rel="full-article" href="{{ .Permalink }}">{{ .Title }}</a>
-                  on <time datetime="{{ .Date }}" pubdate="">{{ .Date.Format "January 2" }}</time>
-                {{ else }}
-                  <a rel="remote-article" href="{{ .Params.externalurl }}">{{ .Title }} →</a>
-                  on
-                  <a href="{{ .Permalink }}"><time datetime="{{ .Date }}" pubdate="">{{ .Date.Format "January 2" }}</time></a>
-                {{ end }}
-              </li>
-            {{ end }}
-          </ul>
-        </div>
-      {{ end }}
-      </div>
-    </article>
-  </main>
+{{ partial "yearly_grouping.html" . }}
 
 {{ partial "page_footer.html" . }}
 {{ partial "site_footer.html" . }}


### PR DESCRIPTION
Adds a parameter called YearlyMicroposts which is used to either:
   - output the usual list of microposts if the parameter is not set or set to
     false;
   - output a list of micropost titles grouped by year (just like the posts list
     is) if the parameter is set and true.
The default behavior is not changed and the setting needs not be defined thus
not complicating the default installation.

I don't know if that is a modification that would be acceptable to you.  I am trying to keep my fork in sync with yours.  I have merged all your latest versions.  I have made sure that (as far as I can tell) there is no modification needed for the default behavior to remain.

It turns out that my microposts are not all that micro, they are more like mini posts.  Because of that, and because of how I tend to look for them, I would like to list them out just like my posts, but still keep them as a separate "type".  That is why I introduced this functionality.  I did not think a third kind of document (posts, miniposts and microposts or something like that) was the way to go.  I do not think it has much effect on sites, as I mentioned.  I have tested with and without the setting and with false and true as the values.

If you feel it's too much trouble and not worth it or something you are not happy with, I understand completely and I'll try and keep it in my fork and continue merging your modifications.

Thanks for the theme by the way.  Really happy with it.