### PR TITLE
Using .URL in menu items instead of .Permalink

### DIFF
--- a/layouts/partials/page_header.html
+++ b/layouts/partials/page_header.html
@@ -7,9 +7,9 @@
 			<ul>
 				{{ range .Site.Menus.main }}
 				<li>
-					<a href="{{.Permalink}}">{{ .Name }}</a>
+					<a href="{{.URL}}">{{ .Name }}</a>
 					{{ if in ($.Scratch.Get "sections") .Name }}
-						<a href="{{.Permalink}}index.xml"><img src="/img/rss.svg" class="rss-icon" /></a>
+						<a href="{{.URL}}index.xml"><img src="/img/rss.svg" class="rss-icon" /></a>
 					{{ end }}
 				</li>
 				{{ end }}


### PR DESCRIPTION
Using .Permalink was causing my site to not compile anymore with version 0.59.1
of Hugo.  According to this issue on the Hugo Github repository:

   https://github.com/gohugoio/hugo/issues/5868

in menus, .URL is not deprecated and can/should be kept.