### PR TITLE
Changing date format to YYYY-MM-dd for datetime attribute.

### DIFF
--- a/layouts/partials/preview_micropost.html
+++ b/layouts/partials/preview_micropost.html
@@ -6,7 +6,7 @@
         <h2><a rel="remote-article" href="{{ .Params.externalurl }}">→ {{ .Title }}</a> <a href="{{ .Permalink }}">∞</a></h2>
     {{ end }}
 
-    <div class="postmeta">Posted on <time datetime="{{ .Date }}" pubdate="">{{ .Date.Format "January 2, 2006" }}</time>
+    <div class="postmeta">Posted on <time datetime='{{ .Date.Format "2006-01-02" }}' pubdate="">{{ .Date.Format "January 2, 2006" }}</time>
       {{ if (isset .Params "categories") }}
         in
         <span class="categories">

--- a/layouts/partials/preview_post.html
+++ b/layouts/partials/preview_post.html
@@ -5,7 +5,7 @@
     <h2><a rel="remote-article" href="{{ .Params.externalurl }}">→ {{ .Title }}</a> <a href="{{ .Permalink }}">∞</a></h2>
   {{ end }}
 
-  <div class="postmeta">Posted on <time datetime="{{ .Date }}" pubdate="">{{ .Date.Format "January 2, 2006" }}</time>
+  <div class="postmeta">Posted on <time datetime='{{ .Date.Format "2006-01-02" }}' pubdate="">{{ .Date.Format "January 2, 2006" }}</time>
     {{ if (isset .Params "categories") }}
        in
       <span class="categories">

--- a/layouts/partials/yearly_grouping.html
+++ b/layouts/partials/yearly_grouping.html
@@ -9,11 +9,11 @@
             <li>
               {{ if (not (isset .Params "externalurl")) }}
                 <a rel="full-article" href="{{ .Permalink }}">{{ .Title }}</a>
-                on <time datetime="{{ .Date }}" pubdate="">{{ .Date.Format "January 2" }}</time>
+                on <time datetime='{{ .Date.Format "2006-01-02" }}' pubdate="">{{ .Date.Format "January 2" }}</time>
               {{ else }}
                 <a rel="remote-article" href="{{ .Params.externalurl }}">{{ .Title }} →</a>
                 on
-                <a href="{{ .Permalink }}"> <time datetime="{{ .Date }}" pubdate="">{{ .Date.Format "January 2" }}</time> </a>
+                <a href="{{ .Permalink }}"> <time datetime='{{ .Date.Format "2006-01-02" }}' pubdate="">{{ .Date.Format "January 2" }}</time> </a>
               {{ end }}
             </li>
           {{ end }}

--- a/layouts/photos/single.html
+++ b/layouts/photos/single.html
@@ -7,7 +7,7 @@
 
       <div class="postmeta">
         {{ with .Params.location }}Photos taken in {{ . }} on {{ end }}
-        <time datetime="{{ .Date }}" pubdate="">{{ .Date.Format "January 2, 2006" }}</time>
+        <time datetime='{{ .Date.Format "2006-01-02" }}' pubdate="">{{ .Date.Format "January 2, 2006" }}</time>
         {{ with .Params.camera }} with {{ . }}{{ end }}
       </div>
 

--- a/layouts/posts/single.html
+++ b/layouts/posts/single.html
@@ -10,7 +10,7 @@
         <h2><a rel="remote-article" href="{{ .Params.externalurl }}">→ {{ .Title }}</a> <a href="{{ .Permalink }}">∞</a></h2>
       {{ end }}
 
-      <div class="postmeta">Posted on <time datetime="{{ .Date }}" pubdate="">{{ .Date.Format "January 2, 2006" }}</time> in
+      <div class="postmeta">Posted on <time datetime='{{ .Date.Format "2006-01-02" }}' pubdate="">{{ .Date.Format "January 2, 2006" }}</time> in
         <span class="categories">
           {{ range $i, $v := .Params.categories }}
             <a class="category" href="/categories/{{ $v | urlize }}">{{ $v }}</a>{{ if ne (len $.Params.categories) (add $i 1) }}, {{ end }}


### PR DESCRIPTION
When I validate this template with https://validator.nu I get an error:
`Error: Bad value 2023-07-06 00:00:00 +0000 UTC for attribute datetime on element [time](https://html.spec.whatwg.org/multipage/#the-time-element): The literal did not satisfy the time-datetime format.`

The issue seems to be that the HTML spec does not allow to format dates that way.
https://html.spec.whatwg.org/multipage/text-level-semantics.html#attr-time-datetime

<img width="1512" alt="image" src="https://github.com/jnjosh/internet-weblog/assets/1487947/1cf0ae02-046c-4493-a126-69eae0cb2f3d">

This pull request is a fix to this issue. After merge the dates are formatted without the time component.
