### PR TITLE
fix: migrate ".Site.Author" to ".Site.Params.Author"

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,10 +97,10 @@ If you aren't sure of how this should look, see how [jnjosh.com uses this in it'
 
 #### Defining yourself as the Author
 
-It looks like most themes use the `author` variable to add something simple like your name. This theme uses more structured data about you and requires an `[author]` section. The details of what is affected by each property is defined below in the variables section, but you should add this section to your `config.toml`:
+It looks like most themes use the `author` variable to add something simple like your name. This theme uses more structured data about you and requires an `[params.author]` section. The details of what is affected by each property is defined below in the variables section, but you should add this section to your `config.toml`:
 
 ```
-[author]
+[params.author]
    Handle = "<Your `handle`>"
    FirstName = "<Your First Name>"
    LastName = "<Your Last Name>"
@@ -109,7 +109,7 @@ It looks like most themes use the `author` variable to add something simple like
    FlickrID = "<Your Flickr ID>"
 ```
 
-**Recommendation:** Don't use the `author` variable, use the above `[author]` section in your `config.toml`.
+**Recommendation:** Don't use the `author` variable, use the above `[params.author]` section in your `config.toml`.
 
 #### Customizing the Bio Section, 404 page, javascript, or stylesheets
 
@@ -150,12 +150,12 @@ If you want to enable a dark appearance, there is limited support for that. Curr
 | `theme`  | `internet-weblog` | Only if you want to use this theme! 😃|
 | `title` | `internet weblog` | No. Unless you want to call your blog something else. |
 | `SectionPagesMenu` | `main` | Yes. See [above](#configuring-your-blog). |
-| `[author]` - `Handle` | A short handle to describe you. This could be your twitter handle or simply your first name. | Yes. This is used to generate the Site's Title. |
-| `[author]` - `FirstName` | Your first name | Yes. This is used in the footer to say Hi and in other places to identify you as the author. |
-| `[author]` - `LastName` | Your last name | Not really. It is used in some places to identify you as the author. |
-| `[author]` - `AboutPage` | `/about` or `http://about.othersite.com` | Only if you want an about page. This is exposed to allow you to link to an external about page as well. If you have a local page it can just be something relative. |
-| `[author]` - `Location` | `Your City` | No. If set, this is added to the Copyright in the footer so you can give some love to your hometown. |
-| `[author]` - `FlickrID` | `Your Flickr ID` | No. The footer shows your photo stream from flickr. If you don't set it, nothing will be displayed. |
+| `[params.author]` - `Handle` | A short handle to describe you. This could be your twitter handle or simply your first name. | Yes. This is used to generate the Site's Title. |
+| `[params.author]` - `FirstName` | Your first name | Yes. This is used in the footer to say Hi and in other places to identify you as the author. |
+| `[params.author]` - `LastName` | Your last name | Not really. It is used in some places to identify you as the author. |
+| `[params.author]` - `AboutPage` | `/about` or `http://about.othersite.com` | Only if you want an about page. This is exposed to allow you to link to an external about page as well. If you have a local page it can just be something relative. |
+| `[params.author]` - `Location` | `Your City` | No. If set, this is added to the Copyright in the footer so you can give some love to your hometown. |
+| `[params.author]` - `FlickrID` | `Your Flickr ID` | No. The footer shows your photo stream from flickr. If you don't set it, nothing will be displayed. |
 | `[params]` - `Description` | `Describe your site` | No. If set, this is added to your pages metadata. |
 | `[params]` - `ShowCopyright` | `true` or `false` | No. If true, Copyright text will be added to the footer. |
 | `[params]` - `EnablePreferredDarkAppearance` | `true` or `false` | No. If true, The viewers system dark mode is respected switching to a dark appearance. |
@@ -175,7 +175,7 @@ theme = "internet-weblog"
 Paginate = 10
 SectionPagesMenu = "main"
 
-[author]
+[params.author]
    Handle = "jnjosh"
    FirstName = "Josh"
    LastName = "Johnson"

--- a/layouts/partials/custom_image_handler.html
+++ b/layouts/partials/custom_image_handler.html
@@ -3,7 +3,7 @@
   // @summary: jquery implementation
   $(function() {
     // @summary: Use the author's flickr ID to load images from the public flickr feed
-    $.getJSON("https://api.flickr.com/services/feeds/photos_public.gne?id={{ .Site.Author.flickrid }}&format=json&jsoncallback=?", function(data) {
+    $.getJSON("https://api.flickr.com/services/feeds/photos_public.gne?id={{ .Site.Params.Author.flickrid }}&format=json&jsoncallback=?", function(data) {
       iweblog.application.displayImages(data, 8);
     });
   });

--- a/layouts/partials/page_footer.html
+++ b/layouts/partials/page_footer.html
@@ -1,14 +1,14 @@
 <footer>
   <div class="footer_text">
       <div>
-        <h3>Hi, <a href="{{ .Site.Author.aboutpage }}">I'm {{ .Site.Author.firstname }}</a></h3>
+        <h3>Hi, <a href="{{ .Site.Params.Author.aboutpage }}">I'm {{ .Site.Params.Author.firstname }}</a></h3>
         <p>
           {{ partial "bio.html" . }}
         </p>
       </div>
-      {{ if isset .Site.Author "flickrid" | and ( not ( eq .Site.Author.flickrid "" ) ) }}
+      {{ if isset .Site.Params.Author "flickrid" | and ( not ( eq .Site.Params.Author.flickrid "" ) ) }}
       <div>
-          <h3><a href="https://www.flickr.com/photos/{{ .Site.Author.flickrid }}/">Photo Stream</a></h3>
+          <h3><a href="https://www.flickr.com/photos/{{ .Site.Params.Author.flickrid }}/">Photo Stream</a></h3>
           <div id="photos"></div>
         </div>
       </div>
@@ -17,8 +17,8 @@
 
   {{ if .Site.Params.showcopyright }}
     <div class="footer_copyright">
-      &copy; {{ now.Format "2006" }} <a href="{{ .Site.Author.aboutpage }}">{{ .Site.Author.firstname }} {{ .Site.Author.lastname }}</a>
-      {{ with .Site.Author.location }} - Made in {{ . }}{{ end }}
+      &copy; {{ now.Format "2006" }} <a href="{{ .Site.Params.Author.aboutpage }}">{{ .Site.Params.Author.firstname }} {{ .Site.Params.Author.lastname }}</a>
+      {{ with .Site.Params.Author.location }} - Made in {{ . }}{{ end }}
     </div>
   {{ end }}
 </footer>

--- a/layouts/partials/page_header.html
+++ b/layouts/partials/page_header.html
@@ -1,6 +1,6 @@
 <header>
   <nav>
-    <h1><a href="/">@{{ .Site.Author.handle }}</a>’s {{ .Site.Title }}.</h1>
+    <h1><a href="/">@{{ .Site.Params.Author.handle }}</a>’s {{ .Site.Title }}.</h1>
     <div class="menu">
 		{{ if isset .Site.Params "rsssections" }}
 			{{ $.Scratch.Add "sections" .Site.Params.rsssections }}
@@ -13,7 +13,7 @@
 					{{ end }}
 				</li>
 				{{ end }}
-				{{ with .Site.Author.aboutpage }}<li><a href="{{ . }}">About</a></li>{{ end }}
+				{{ with .Site.Params.Author.aboutpage }}<li><a href="{{ . }}">About</a></li>{{ end }}
 			</ul>
 		{{ else }}
 			<ul>
@@ -22,7 +22,7 @@
 					<a href="{{.URL}}">{{ .Name }}</a>
 				</li>
 				{{ end }}
-				{{ with .Site.Author.aboutpage }}<li><a href="{{ . }}">About</a></li>{{ end }}
+				{{ with .Site.Params.Author.aboutpage }}<li><a href="{{ . }}">About</a></li>{{ end }}
 			</ul>
       	{{ end }}
     </div>

--- a/layouts/partials/site_header.html
+++ b/layouts/partials/site_header.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="author" content="{{ with .Site.Author.firstname }}{{ . }}{{ end }} {{ with .Site.Author.lastname }}{{ . }}{{ end }}">
+    <meta name="author" content="{{ with .Site.Params.Author.firstname }}{{ . }}{{ end }} {{ with .Site.Params.Author.lastname }}{{ . }}{{ end }}">
     <meta name="description" content="{{ with .Site.Params.description }}{{ . }}{{ end }}">
 
     {{ $siteTitle := .Site.Title }} {{ $title := $siteTitle }}{{ if .IsPage }}{{ $title = .Title }}
@@ -13,12 +13,12 @@
     {{ if .Param "feature" }}<meta property="og:image" content="{{ .Site.BaseURL }}{{ .Params.feature }}">{{ end }}
     <meta property="og:url" content="{{ .Page.Permalink }}">
     <meta property="og:description" content="{{ .Summary }}">
-    <meta property="og:site_name" content="@{{ .Site.Author.handle }}’s {{ .Site.Title }}">
+    <meta property="og:site_name" content="@{{ .Site.Params.Author.handle }}’s {{ .Site.Title }}">
     <meta name="twitter:card" content="summary_large_image">
     {{ end }}
     {{ hugo.Generator }}
     {{ $.Scratch.Add "title" .Site.Title }}
-    <title>{{ with .Title }}{{ if ne . ($.Scratch.Get "title") }}{{ . }} &middot; {{ end }}{{ end }}@{{ .Site.Author.handle }}’s {{ .Site.Title }}</title>
+    <title>{{ with .Title }}{{ if ne . ($.Scratch.Get "title") }}{{ . }} &middot; {{ end }}{{ end }}@{{ .Site.Params.Author.handle }}’s {{ .Site.Title }}</title>
 
     <link rel="stylesheet" href="{{.Site.BaseURL}}css/joshin-color-palette.css" media="screen" charset="utf-8" />
     <link rel="stylesheet" href="{{.Site.BaseURL}}css/joshin-color-light.css" media="screen" charset="utf-8" />

--- a/layouts/rss.xml
+++ b/layouts/rss.xml
@@ -1,6 +1,6 @@
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
-    <title>@{{ .Site.Author.handle }}’s {{ .Site.Title }}{{ with .Title }} - {{ . }}{{ end }}</title>
+    <title>@{{ .Site.Params.Author.handle }}’s {{ .Site.Title }}{{ with .Title }} - {{ . }}{{ end }}</title>
     <link>{{ .Site.BaseURL }}{{ .Permalink }}</link>
     <description>All entries {{ with .Title }}in {{.}} {{ end }}on {{ .Site.Title }}</description>
     <generator>Hugo -- gohugo.io</generator>
@@ -14,7 +14,7 @@
         <title>{{ .Title }}</title>
         <link>{{ .Permalink }}</link>
         <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
-        <author>{{ with .Site.Author.email }}{{.}} - {{end}}{{ with .Site.Author.firstname }}{{.}}{{ end }} {{ with .Site.Author.lastname }}{{.}}{{end}}</author>
+        <author>{{ with .Site.Params.Author.email }}{{.}} - {{end}}{{ with .Site.Params.Author.firstname }}{{.}}{{ end }} {{ with .Site.Params.Author.lastname }}{{.}}{{end}}</author>
         <guid>{{ .Permalink }}</guid>
         <description>{{ .Content | html }}</description>
       </item>

--- a/layouts/section/microposts.rss.xml
+++ b/layouts/section/microposts.rss.xml
@@ -1,6 +1,6 @@
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
-    <title>@{{ .Site.Author.handle }}’s {{ .Site.Title }}{{ with .Title }} - {{ . }}{{ end }}</title>
+    <title>@{{ .Site.Params.Author.handle }}’s {{ .Site.Title }}{{ with .Title }} - {{ . }}{{ end }}</title>
     <link>{{ .Permalink }}</link>
     <description>All entries {{ with .Title }}in {{.}} {{ end }}on {{ .Site.Title }}</description>
     <generator>Hugo -- gohugo.io</generator>
@@ -17,7 +17,7 @@
         {{ end }}
         <link>{{ .Permalink }}</link>
         <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
-        <author>{{ with .Site.Author.email }}{{.}} - {{end}}{{ with .Site.Author.firstname }}{{.}}{{ end }} {{ with .Site.Author.lastname }}{{.}}{{end}}</author>
+        <author>{{ with .Site.Params.Author.email }}{{.}} - {{end}}{{ with .Site.Params.Author.firstname }}{{.}}{{ end }} {{ with .Site.Params.Author.lastname }}{{.}}{{end}}</author>
         <guid>{{ .Permalink }}</guid>
         <description>{{ .Content | html }}</description>
       </item>


### PR DESCRIPTION
# Fix deprecated `.Site.Author` usage

## Context
`.Site.Author` has been deprecated since Hugo v0.124.0 and removed in v0.139.0. When building with Hugo ≥ v0.139.0, it raises the following error:

> ERROR deprecated: .Site.Author was deprecated in Hugo v0.124.0 and will be removed in Hugo v0.139.0. Implement taxonomy 'author' or use .Site.Params.Author instead.

Note: This error appears even in v0.138.0 (via Homebrew), suggesting the deprecation was enforced earlier than documented.

## Changes
- Replace `.Site.Author` with `.Site.Params.Author` throughout the theme
- Update README with new configuration requirements

## Implementation Details
This is a minimal change to maintain compatibility with newer Hugo versions while avoiding breaking changes. The solution follows Hugo's recommended approach of using `.Site.Params.Author`.

## Testing
Tested with:
- `hugo v0.138.0+extended+withdeploy darwin/arm64 BuildDate=2024-11-06T11:22:34Z VendorInfo=brew`

## Notes
- If this PR doesn't align with best practices or the project's future direction, please feel free to close it as I'm relatively new to web development.
- This PR is submitted to document this issue for other theme users who might encounter the same problem.
- Neat theme, BTW.